### PR TITLE
Add Cloudflare deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,17 @@ This repository contains a simple static website for the **Universal TV Remote L
 - `privacy.html` &ndash; the privacy policy.
 
 Open `index.html` in your browser to view the site locally.
+
+## Deploying to Cloudflare Pages
+
+You can host this static site on **Cloudflare Pages** by connecting the
+repository to a new Pages project:
+
+1. Sign in to Cloudflare and create a new Pages project.
+2. Select this repository and use the default build settings (no build command;
+   output directory `/`).
+3. After the first deployment finishes, Cloudflare will provide a URL where the
+   site is accessible.
+
+Connecting the repository allows each commit to trigger a new build on
+Cloudflare Pages automatically.


### PR DESCRIPTION
## Summary
- add steps for deploying the site on Cloudflare Pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887e11ba6d8832dad7b896af933ccc4